### PR TITLE
add script-tag-hook option for e.g. cookie consent

### DIFF
--- a/dist/core/index.js
+++ b/dist/core/index.js
@@ -3,10 +3,15 @@
 var addScriptPromise = 0;
 /** Adds proviced script to the page, once **/
 
-function addPlatformScript(src) {
+function addPlatformScript(src, scriptTagHook) {
   if (!addScriptPromise) {
     var s = document.createElement('script');
     s.setAttribute('src', src);
+
+    if (scriptTagHook) {
+      scriptTagHook(s);
+    }
+
     document.body.appendChild(s);
     addScriptPromise = new Promise(function (resolve) {
       s.onload = function () {
@@ -28,6 +33,9 @@ var defaultProps = {
   },
   slug: {
     type: String
+  },
+  scriptTagHook: {
+    type: Function
   },
   options: Object
   /** Basic function used to mount Twitter component */
@@ -63,7 +71,7 @@ var twitterEmbedComponent = function twitterEmbedComponent(me) {
         params = this.id;
       }
 
-      Promise.resolve(window.twttr ? window.twttr : addPlatformScript('//platform.twitter.com/widgets.js')).then(function (twttr) {
+      Promise.resolve(window.twttr ? window.twttr : addPlatformScript('//platform.twitter.com/widgets.js', this.scriptTagHook)).then(function (twttr) {
         return me.embedComponent(twttr, params, _this.$el, _this.options);
       }).then(function (data) {
         _this.isAvailable = data !== undefined;

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,25 @@ https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guide
 Only `sourceType`: `profile`, `likes` and `list` are integrated. Embedded-Timeline Options Reference:
 https://dev.twitter.com/web/embedded-timelines/parameters
 
+## Intercepting the `<script>` tag to e.g. comply with cookie consent regulation
+
+Before adding the script tag to DOM, change its `src` to `data-src` and add `data-cookieconsent`.
+
+```javascript
+<Timeline ... :script-tag-hook="suspendLoading"/>
+
+// ...
+
+methods: {
+    // this callback is called just before scriptTag is added to DOM.
+    suspendLoading(scriptTag) {
+        scriptTag.dataset.src = scriptTag.src
+        scriptTag.removeAttribute('src')
+        scriptTag.dataset.cookieconsent = 'marketing'
+    }
+
+}
+```
 
 ## Showing a placeholder while the tweet is being loaded
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,10 +1,13 @@
 let addScriptPromise = 0
 
 /** Adds proviced script to the page, once **/
-function addPlatformScript(src) {
+function addPlatformScript(src, scriptTagHook) {
     if (!addScriptPromise) {
         const s = document.createElement('script')
         s.setAttribute('src', src)
+        if (scriptTagHook) {
+            scriptTagHook(s)
+        }
         document.body.appendChild(s)
         addScriptPromise = new Promise(resolve => {
             s.onload = () => {
@@ -25,6 +28,9 @@ const defaultProps = {
     },
     slug: {
         type: String
+    },
+    scriptTagHook: {
+        type: Function
     },
     options: Object
 }
@@ -49,7 +55,7 @@ const twitterEmbedComponent = (me) => {
                 params = this.id
             }
 
-            Promise.resolve(window.twttr ? window.twttr : addPlatformScript('//platform.twitter.com/widgets.js'))
+            Promise.resolve(window.twttr ? window.twttr : addPlatformScript('//platform.twitter.com/widgets.js', this.scriptTagHook))
                 .then(twttr => me.embedComponent(twttr, params, this.$el, this.options))
                 .then(data => {
                     this.isAvailable = (data !== undefined)


### PR DESCRIPTION
Hello!

I'm proposing this PR as a way to suspend loading the Twitter platform `script` tag while we wait for the user to click on a cookie consent banner. This can be used with e.g. [Cookiebot manual mode](https://www.cookiebot.com/en/manual-implementation/).